### PR TITLE
feat: add delete sObject function

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,25 @@ async function upsertSObjectByExternalIdExample() {
 upsertSObjectByExternalIdExample()
 ```
 
+#### deleteSObject
+Delete a record of a specific Salesforce object using the provided data.
+```javascript
+async function deleteSObjectExample() {
+  const sObjectName = 'Account'
+  const recordId = '0011t00000B0lOMAAZ'
+
+  try {
+    await connector.deleteSObject({ sObjectName, recordId })
+    console.log('Record deleted successfully')
+  } catch (error) {
+    console.error('Error deleting record:', error)
+  }
+}
+
+deleteSObjectExample()
+```
+
+
 #### soqlQuery
 Execute a SOQL (Salesforce Object Query Language) query and retrieve the results.
 
@@ -318,7 +337,6 @@ async function getKnowledgeArticlesListExample() {
 ## Upcoming
 
 Other features will be added that use the standard salesforce api:
-- [delete sobject](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_delete_record.htm)
 - [composite graph support](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_graph.htm)
 - [composite tree support](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobject_tree.htm)
 - [composite sobject support](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections.htm)

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -9,6 +9,7 @@ describe('index', () => {
         expect(connector).toHaveProperty('createSObject')
         expect(connector).toHaveProperty('updateSObject')
         expect(connector).toHaveProperty('upsertSObjectByExternalId')
+        expect(connector).toHaveProperty('deleteSObject')
         expect(connector).toHaveProperty('soqlQuery')
         expect(connector).toHaveProperty('soslQuery')
         expect(connector).toHaveProperty('apexRest')

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { makeCreateCompositeSubRequestUpsertSObjectByExternalId } from './operat
 import { makeCreateCompositeSubRequestSoqlQuery } from './operations/composite/requests/soql-query'
 import { makeApexRest } from './operations/apex-rest'
 import { makeGetKnowledgeArticlesList } from './operations/knowledge-articles/support-knowledge/articles-list'
+import { makeDeleteSObject } from './operations/delete-sobject'
 
 import type { Got } from 'got'
 import got from 'got'
@@ -153,6 +154,17 @@ export function makeSalesforceConnector(options: ConnectorOptions) {
          * @returns {Promise<UpsertSObjectResult>} A Promise that resolves to the result of the upsert operation.
          */
         upsertSObjectByExternalId: makeUpsertSObjectByExternalId({ gotInstance }),
+        /**
+         * Deletes a record of a specific Salesforce object using the provided data.
+         *
+         * Implements this api:
+         * @link https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_update_fields.htm
+         * @param {string} sObjectName - The name of the Salesforce object to update a record for.
+         * @param {string} recordId - The ID of the record that will be updated.
+         * @param {ExtendableOptions} extendOptions - Additional options to extend the HTTP request.
+         * @returns {Promise<void>} No returns for successful operations, as Salesforce returns 204 - No Content.
+         */
+        deleteSObject: makeDeleteSObject({ gotInstance }),
         /**
          * Executes a SOSL (Salesforce Object Search Language) query and retrieves the results.
          * For more information regarding sosl:

--- a/src/operations/delete-sobject/index.spec.ts
+++ b/src/operations/delete-sobject/index.spec.ts
@@ -1,0 +1,42 @@
+import { makeDeleteSObject } from './index'
+
+import { SALESFORCE_REST_API_VERSION } from '../../constants'
+
+import got, { Got } from 'got'
+import nock, { disableNetConnect } from 'nock'
+
+beforeAll(() => {
+    disableNetConnect()
+})
+
+const sObjectName = 'Account'
+const recordId = '0010A000000aAAaAAA'
+const baseUrl = 'https://bolo.example.com/'
+const path = `/services/data/${SALESFORCE_REST_API_VERSION}/sobjects/${sObjectName}/${recordId}`
+
+describe('deleteSObject', () => {
+    const gotInstance: Got = got.extend({
+        prefixUrl: baseUrl,
+    })
+
+    const deleteSObject = makeDeleteSObject({ gotInstance })
+
+    it('should delete sobject in salesforce', async () => {
+        const scope = nock(baseUrl).delete(path).reply(204)
+
+        await deleteSObject({ sObjectName, recordId })
+
+        expect(scope.isDone()).toBe(true)
+    })
+    it('should fail to delete sobject in salesforce', async () => {
+        // Create a scope that will match the exact request URL
+        const scope = nock(baseUrl).delete(path).reply(500).persist()
+
+        await expect(async () => await deleteSObject({ sObjectName, recordId })).rejects.toThrow(
+            'Response code 500 (Internal Server Error)'
+        )
+
+        // Verify the nock interceptor was used
+        expect(scope.isDone()).toBe(true)
+    })
+})

--- a/src/operations/delete-sobject/index.ts
+++ b/src/operations/delete-sobject/index.ts
@@ -1,0 +1,40 @@
+import { SALESFORCE_REST_API_VERSION } from '../../constants'
+import type { ExtendableOptions } from '../../types'
+
+import type { Got, Options } from 'got'
+
+export function makeDeleteSObject({ gotInstance }: { gotInstance: Got }) {
+    /**
+     * Deletes a record of a specific Salesforce object using the provided data.
+     *
+     * Implements this api:
+     * @link https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_delete_record.htm
+     * @param {string} sObjectName - The name of the Salesforce object to delete a record for.
+     * @param {string} recordId - The ID of the record that will be deleted.
+     * @param {ExtendableOptions} extendOptions - Additional options to extend the HTTP request.
+     * @returns {Promise<void>} No returns for successful operations, as Salesforce returns 204 - No Content.
+     */
+    return async function deleteSObject({
+        sObjectName,
+        recordId,
+        extendOptions = {},
+    }: {
+        sObjectName: string
+        recordId: string
+        extendOptions?: ExtendableOptions
+    }): Promise<void> {
+        const got = gotInstance.extend(extendOptions)
+
+        const options: Options = {
+            headers: {
+                'content-type': 'application/json',
+            },
+            responseType: 'json',
+        }
+
+        await got.delete(
+            `services/data/${SALESFORCE_REST_API_VERSION}/sobjects/${sObjectName}/${recordId}`,
+            options
+        )
+    }
+}


### PR DESCRIPTION
This MR will introduce the standard salesforce `DELETE` object functionality https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_delete_record.htm

- Tested the new functionality locally by making calls to a salesforce environment.